### PR TITLE
Extract JSDoc modifier parser

### DIFF
--- a/kdts/gcc/generator.ts
+++ b/kdts/gcc/generator.ts
@@ -804,6 +804,8 @@ class GccGenerator extends Generator {
       this.put("@nosideeffects", true);
     if (modifiers & Modifier.Inline)
       this.put("@requireInlining", true);
+    if (modifiers & Modifier.InlineFriendly)
+      this.put("@encourageInlining", true);
 
     let i = 0;
     for (let param of params) {

--- a/kdts/gcc/generator.ts
+++ b/kdts/gcc/generator.ts
@@ -802,7 +802,7 @@ class GccGenerator extends Generator {
       this.put("@noinline", true);
     if (hasAll(modifiers, Modifier.SideEffectFree))
       this.put("@nosideeffects", true);
-    if (modifiers & Modifier.RequireInline)
+    if (modifiers & Modifier.Inline)
       this.put("@requireInlining", true);
 
     let i = 0;

--- a/kdts/gcc/test/functions.test.ts
+++ b/kdts/gcc/test/functions.test.ts
@@ -158,6 +158,26 @@ describe("FunctionDeclaration", ()=>{
     `);
   });
 
+  test("emits encourageInlining for InlineFriendlyFn declarations", () => {
+    expectEmit(`
+      /** @satisfies {InlineFriendlyFn} */
+      function arr<T>(x: T[] | T): T[] {
+        return Array.isArray(x) ? x : [x];
+      }
+    `, `
+      /**
+       * @suppress {reportUnknownTypes}
+       * @template T
+       * @encourageInlining
+       * @param {(!Array<!T>|!T)} x
+       * @return {!Array<!T>}
+       */
+      function arr(x) {
+        return (Array.isArray(x) ? x : [x]);
+      }
+    `);
+  });
+
   test("generator syntax", () => {
     expectEmit(`
       function* ids(limit: number): Generator<number> {

--- a/kdts/gcc/test/functions.test.ts
+++ b/kdts/gcc/test/functions.test.ts
@@ -138,9 +138,9 @@ describe("FunctionDeclaration", ()=>{
     `);
   });
 
-  test("emits requireInlining for requireInlining declarations", () => {
+  test("emits requireInlining for InlineFn declarations", () => {
     expectEmit(`
-      /** @requireInlining */
+      /** @satisfies {InlineFn} */
       function arr<T>(x: T[] | T): T[] {
         return Array.isArray(x) ? x : [x];
       }

--- a/kdts/model/modifier.ts
+++ b/kdts/model/modifier.ts
@@ -7,8 +7,8 @@ enum Modifier {
   Override = 16,
 
   // A VariableDeclaration whose init should be moved to callsite.
-  RequireInline = 1 << 7,
-  EncourageInline = 1 << 8,
+  Inline = 1 << 7,
+  InlineFriendly = 1 << 8,
   NoInline = 1 << 9,
 
   ReadonlyArguments = 1 << 20,
@@ -28,54 +28,4 @@ enum Modifier {
 
 const hasAll = (lhs: Modifier, rhs: Modifier): boolean => (lhs & rhs) == rhs;
 
-const JsDocModifierMap: Record<string, Modifier | -1> = {
-  "requireInlining": Modifier.RequireInline,
-  "encourageInlining": Modifier.EncourageInline,
-  "satisfies": -1,
-  "satisfies {InlineFn}": Modifier.RequireInline,
-  "satisfies {InPlaceFn}": Modifier.InPlace,
-  "satisfies {InPlaceRandFn}": Modifier.InPlaceRand,
-  "satisfies {MethodFn}": Modifier.Method,
-  "satisfies {SideEffectFreeFn}": Modifier.SideEffectFree,
-  "satisfies {PureAliasFn}": Modifier.PureAlias,
-  "satisfies {PureFn}": Modifier.Pure,
-};
-
-const isWhitespace = (charCode: number): boolean => charCode <= 32;
-
-const modifiersFromJsDoc = (jsDoc: string): number => {
-  let modifiers = 0;
-  const parts = jsDoc.split("@");
-
-  for (let i = 1; i < parts.length; ++i) {
-    const part = parts[i];
-    let cursor = 0;
-    while (cursor < part.length && !isWhitespace(part.charCodeAt(cursor)))
-      ++cursor;
-    if (!cursor) continue;
-
-    const directive = part.slice(0, cursor);
-    const rule = JsDocModifierMap[directive];
-    if (rule == undefined) continue;
-    if (rule != -1) {
-      modifiers |= rule;
-      continue;
-    }
-
-    while (cursor < part.length && isWhitespace(part.charCodeAt(cursor)))
-      ++cursor;
-    if (part.charCodeAt(cursor) != 123) continue;
-
-    const bracedEnd = part.indexOf("}", cursor + 1);
-    if (bracedEnd == -1) continue;
-
-    const bracedRule =
-      JsDocModifierMap[`${directive} ${part.slice(cursor, bracedEnd + 1)}`];
-    if (bracedRule != undefined && bracedRule != -1)
-      modifiers |= bracedRule;
-  }
-
-  return modifiers;
-}
-
-export { Modifier, modifiersFromJsDoc, hasAll };
+export { Modifier, hasAll };

--- a/kdts/parser/jsdocParser.ts
+++ b/kdts/parser/jsdocParser.ts
@@ -1,0 +1,49 @@
+import { Modifier } from "../model/modifier";
+
+const SatisfiesTag = "@satisfies";
+const FnSuffix = "Fn";
+
+const isWhitespace = (charCode: number): boolean => charCode <= 32;
+
+const modifierFromSatisfiesIdent = (ident: string): number => {
+  if (!ident.endsWith(FnSuffix))
+    return 0;
+
+  const modifier = Modifier[ident.slice(0, -FnSuffix.length) as keyof typeof Modifier];
+  return typeof modifier == "number" ? modifier : 0;
+}
+
+const modifiersFromSatisfiesClause = (clause: string): number => {
+  let modifiers = 0;
+  const parts = clause.split("&");
+
+  for (let i = 0; i < parts.length; ++i)
+    modifiers |= modifierFromSatisfiesIdent(parts[i]!.trim());
+
+  return modifiers;
+}
+
+const modifiersFromJsDoc = (jsDoc: string): number => {
+  let modifiers = 0;
+  const parts = jsDoc.split(SatisfiesTag);
+
+  for (let i = 1; i < parts.length; ++i) {
+    const part = parts[i]!;
+    let cursor = 0;
+
+    while (cursor < part.length && isWhitespace(part.charCodeAt(cursor)))
+      ++cursor;
+    if (part.charCodeAt(cursor) != 123)
+      continue;
+
+    const bracedEnd = part.indexOf("}", cursor + 1);
+    if (bracedEnd == -1)
+      continue;
+
+    modifiers |= modifiersFromSatisfiesClause(part.slice(cursor + 1, bracedEnd));
+  }
+
+  return modifiers;
+}
+
+export { modifiersFromJsDoc };

--- a/kdts/parser/test/modifierFromAnnotation.test.js
+++ b/kdts/parser/test/modifierFromAnnotation.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { Modifier } from "../../model/modifier";
+import { modifiersFromJsDoc } from "../jsdocParser";
 import { parseSource } from "./utils";
 
 test("modifier from JSDoc attaches to statement-level VariableDeclaration, not nested one", () => {
@@ -36,9 +37,20 @@ test("Function modifiers attach on ArrowFunctionExpressions", () => {
   expect(innerFn.modifiers).toBe(Modifier.Pure);
 });
 
-test("AlwaysInline modifiers attach on FunctionDeclarations", () => {
+test("modifiersFromJsDoc ORs @satisfies entries and ignores unknown modifiers", () => {
+  const modifiers = modifiersFromJsDoc(`
+    * @satisfies {DeterministicFn & InlineFn & UnknownFn}
+    * @satisfies {InlineFriendlyFn}
+  `);
+
+  expect(modifiers).toBe(
+    Modifier.Deterministic | Modifier.Inline | Modifier.InlineFriendly
+  );
+});
+
+test("Inline modifiers attach on FunctionDeclarations", () => {
   const ast = parseSource(`
-    /** @requireInlining */
+    /** @satisfies {InlineFn} */
     function arr<T>(x: T[] | T): T[] {
       return Array.isArray(x) ? x : [x];
     }
@@ -46,7 +58,22 @@ test("AlwaysInline modifiers attach on FunctionDeclarations", () => {
   const stmt = ast.body[0];
   expect(stmt.type).toBe("FunctionDeclaration");
   expect(stmt.id.name).toBe("arr");
-  expect(stmt.modifiers).toBe(Modifier.RequireInline);
+  expect(stmt.modifiers).toBe(Modifier.Inline);
+});
+
+test("multiple @satisfies tags accumulate on the parsed node", () => {
+  const ast = parseSource(`
+    /**
+     * @satisfies {DeterministicFn & InlineFn}
+     * @satisfies {InlineFriendlyFn & UnknownFn}
+     */
+    const run = () => 1;
+  `);
+  const stmt = ast.body[0];
+  expect(stmt.type).toBe("VariableDeclaration");
+  expect(stmt.modifiers).toBe(
+    Modifier.Deterministic | Modifier.Inline | Modifier.InlineFriendly
+  );
 });
 
 test("Function modifiers attach on parenthesized destructuring ArrowFunctionExpressions", () => {

--- a/kdts/parser/tsParser.ts
+++ b/kdts/parser/tsParser.ts
@@ -11,11 +11,11 @@ import { DecoratorsError, TypeScriptError } from "./error";
 import generateParseDecorators from "./extentions/decorators";
 import generateParseImportAssertions from "./extentions/import-assertions";
 import generateJsxParser from "./extentions/jsx";
+import { modifiersFromJsDoc } from "./jsdocParser";
 import { AcornParseClass } from "./middleware";
 import { checkKeyName, DestructuringErrors, isPrivateNameConflicted } from "./parseutil";
 import { TS_SCOPE_OTHER, TS_SCOPE_TS_MODULE } from "./scopeflags";
 import { generateAcornTypeScript } from "./tokenType";
-import { modifiersFromJsDoc } from "../model/modifier";
 import {
   Accessibility,
   LookaheadState,


### PR DESCRIPTION
## Summary
- move JSDoc modifier parsing out of kdts/model/modifier.ts into kdts/parser/jsdocParser.ts
- parse only @satisfies clauses by splitting on @satisfies and OR matching Modifier entries from *Fn identifiers
- update parser/emitter tests and keep Inline modifiers emitting @requireInlining in GCC output

## Testing
- bun test kdts/parser/test/modifierFromAnnotation.test.js
- bun test kdts/gcc/test/functions.test.ts